### PR TITLE
Add classroom enrollment section and admin overview

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,6 +26,10 @@ const initialState = {
   transactions: [],
   recurring: [],
   budgets: [],
+  classes: [
+    { id: uid("class"), name: "Financial Literacy 101", code: "1010", students: [] },
+    { id: uid("class"), name: "Smart Saving Strategies", code: "2020", students: [] },
+  ],
 };
 
 function clone(x){ return JSON.parse(JSON.stringify(x)); }
@@ -214,6 +218,113 @@ function Transactions({ state, setState }){
             </div>
           ))}
           {list.length === 0 && <div className="opacity-70">No transactions yet.</div>}
+        </div>
+      </Card>
+    </div>
+  );
+}
+
+function Classes({ state, setState }){
+  const [studentName, setStudentName] = useState("");
+  const [classCode, setClassCode] = useState("");
+  const [status, setStatus] = useState(null);
+
+  const join = () => {
+    const name = studentName.trim();
+    const code = classCode.trim();
+    if (!name || !code) {
+      setStatus({ type: "error", message: "Enter your name and class code." });
+      return;
+    }
+    const copy = clone(state);
+    const cls = copy.classes.find(c => c.code === code);
+    if (!cls) {
+      setStatus({ type: "error", message: "Class code not found." });
+      return;
+    }
+    if (!cls.students.some(s => s.name.toLowerCase() === name.toLowerCase())) {
+      cls.students.push({ id: uid("student"), name, joinedAt: new Date() });
+    }
+    setState(copy);
+    setStatus({ type: "success", message: `Joined ${cls.name}` });
+    setStudentName("");
+    setClassCode("");
+  };
+
+  return (
+    <Card title="Join Your Class">
+      <p className="text-sm opacity-80 mb-3">Use the code from your teacher to join their TeenBank classroom.</p>
+      <Field label="Your Name">
+        <input value={studentName} onChange={e=>setStudentName(e.target.value)} placeholder="Jordan" className="w-full px-3 py-2 rounded-xl bg-white/10 border border-white/15"/>
+      </Field>
+      <Field label="Class Code">
+        <input value={classCode} onChange={e=>setClassCode(e.target.value)} placeholder="1010" className="w-full px-3 py-2 rounded-xl bg-white/10 border border-white/15"/>
+      </Field>
+      <div className="flex gap-2 items-center">
+        <Button onClick={join}>Join Class</Button>
+        {status && (
+          <span className={`text-xs ${status.type === "error" ? "text-red-300" : "text-green-300"}`}>{status.message}</span>
+        )}
+      </div>
+    </Card>
+  );
+}
+
+function AdminPanel({ state, setState }){
+  const [className, setClassName] = useState("");
+  const [classCode, setClassCode] = useState("");
+  const classes = state.classes;
+
+  const create = () => {
+    const name = className.trim();
+    const code = classCode.trim();
+    if (!name || !code) return;
+    const copy = clone(state);
+    if (copy.classes.some(c => c.code === code)) return;
+    copy.classes.push({ id: uid("class"), name, code, students: [] });
+    setState(copy);
+    setClassName("");
+    setClassCode("");
+  };
+
+  return (
+    <div className="grid md:grid-cols-2 gap-4">
+      <Card title="Create Class">
+        <Field label="Class Name">
+          <input value={className} onChange={e=>setClassName(e.target.value)} placeholder="Investing Basics" className="w-full px-3 py-2 rounded-xl bg-white/10 border border-white/15"/>
+        </Field>
+        <Field label="Class Code">
+          <input value={classCode} onChange={e=>setClassCode(e.target.value)} placeholder="3030" className="w-full px-3 py-2 rounded-xl bg-white/10 border border-white/15"/>
+        </Field>
+        <Button onClick={create}>Add Class</Button>
+      </Card>
+
+      <Card title="Classes Overview">
+        <div className="space-y-3 max-h-80 overflow-auto pr-1">
+          {classes.map(cls => (
+            <div key={cls.id} className="bg-white/5 rounded-xl p-3">
+              <div className="flex items-center justify-between mb-2">
+                <div>
+                  <div className="font-semibold">{cls.name}</div>
+                  <div className="text-xs opacity-70">Code: {cls.code}</div>
+                </div>
+                <div className="text-xs opacity-70">{cls.students.length} student{cls.students.length === 1 ? "" : "s"}</div>
+              </div>
+              {cls.students.length === 0 ? (
+                <div className="text-xs opacity-60">No students joined yet.</div>
+              ) : (
+                <ul className="text-sm space-y-1">
+                  {cls.students.map(s => (
+                    <li key={s.id} className="flex justify-between bg-white/5 rounded-lg px-2 py-1">
+                      <span>{s.name}</span>
+                      <span className="text-xs opacity-60">{new Date(s.joinedAt).toLocaleDateString()}</span>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          ))}
+          {classes.length === 0 && <div className="opacity-70">No classes created.</div>}
         </div>
       </Card>
     </div>
@@ -422,7 +533,7 @@ function Statements({ state }){
 
 // -------------------- App Shell --------------------
 function Tabs({ tab, setTab }){
-  const items = ["Onboarding","Accounts","Transactions","Recurring","Budgets","Statements"];
+  const items = ["Onboarding","Accounts","Transactions","Classes","Recurring","Budgets","Statements","Admin"];
   return (
     <div className="flex flex-wrap gap-2 mb-4">
       {items.map(name => (
@@ -451,9 +562,11 @@ export default function TeenBankApp(){
         {tab === "Onboarding" && <Onboarding state={state} setState={setState} />}
         {tab === "Accounts" && <Accounts state={state} setState={setState} />}
         {tab === "Transactions" && <Transactions state={state} setState={setState} />}
+        {tab === "Classes" && <Classes state={state} setState={setState} />}
         {tab === "Recurring" && <Recurring state={state} setState={setState} />}
         {tab === "Budgets" && <Budgets state={state} setState={setState} />}
         {tab === "Statements" && <Statements state={state} />}
+        {tab === "Admin" && <AdminPanel state={state} setState={setState} />}
 
         <footer className="mt-8 text-xs opacity-70">© {new Date().getFullYear()} TeenBank (prototype)</footer>
       </div>

--- a/index.html
+++ b/index.html
@@ -224,7 +224,7 @@ function Transactions({ state, setState }){
   );
 }
 
-function Classes({ state, setState }){
+function StudentJoinCard({ state, setState, onJoined }){
   const [studentName, setStudentName] = useState("");
   const [classCode, setClassCode] = useState("");
   const [status, setStatus] = useState(null);
@@ -246,13 +246,17 @@ function Classes({ state, setState }){
       cls.students.push({ id: uid("student"), name, joinedAt: new Date() });
     }
     setState(copy);
-    setStatus({ type: "success", message: `Joined ${cls.name}` });
+    const message = `Joined ${cls.name}`;
+    setStatus({ type: "success", message });
+    if (onJoined) {
+      onJoined({ name, classId: cls.id, className: cls.name });
+    }
     setStudentName("");
     setClassCode("");
   };
 
   return (
-    <Card title="Join Your Class">
+    <Card title="Student Join">
       <p className="text-sm opacity-80 mb-3">Use the code from your teacher to join their TeenBank classroom.</p>
       <Field label="Your Name">
         <input value={studentName} onChange={e=>setStudentName(e.target.value)} placeholder="Jordan" className="w-full px-3 py-2 rounded-xl bg-white/10 border border-white/15"/>
@@ -325,6 +329,40 @@ function AdminPanel({ state, setState }){
             </div>
           ))}
           {classes.length === 0 && <div className="opacity-70">No classes created.</div>}
+        </div>
+      </Card>
+    </div>
+  );
+}
+
+function LoginScreen({ state, setState, onStudentEnter, onAdminEnter }){
+  const [adminCode, setAdminCode] = useState("");
+  const [adminStatus, setAdminStatus] = useState(null);
+
+  const accessAdmin = () => {
+    const code = adminCode.trim();
+    if (code.toLowerCase() === "admin") {
+      setAdminStatus({ type: "success", message: "Welcome back!" });
+      setAdminCode("");
+      onAdminEnter();
+    } else {
+      setAdminStatus({ type: "error", message: "Incorrect admin code." });
+    }
+  };
+
+  return (
+    <div className="grid md:grid-cols-2 gap-4">
+      <StudentJoinCard state={state} setState={setState} onJoined={onStudentEnter} />
+      <Card title="Admin Access">
+        <p className="text-sm opacity-80 mb-3">Enter the admin access code to manage classes and view rosters.</p>
+        <Field label="Access Code">
+          <input value={adminCode} onChange={e=>setAdminCode(e.target.value)} placeholder="admin" className="w-full px-3 py-2 rounded-xl bg-white/10 border border-white/15"/>
+        </Field>
+        <div className="flex gap-2 items-center">
+          <Button onClick={accessAdmin}>Enter Admin</Button>
+          {adminStatus && (
+            <span className={`text-xs ${adminStatus.type === "error" ? "text-red-300" : "text-green-300"}`}>{adminStatus.message}</span>
+          )}
         </div>
       </Card>
     </div>
@@ -532,8 +570,7 @@ function Statements({ state }){
 }
 
 // -------------------- App Shell --------------------
-function Tabs({ tab, setTab }){
-  const items = ["Onboarding","Accounts","Transactions","Classes","Recurring","Budgets","Statements","Admin"];
+function Tabs({ tab, setTab, items }){
   return (
     <div className="flex flex-wrap gap-2 mb-4">
       {items.map(name => (
@@ -546,27 +583,66 @@ function Tabs({ tab, setTab }){
 export default function TeenBankApp(){
   const [state, setState] = useState(initialState);
   const [tab, setTab] = useState("Onboarding");
+  const [session, setSession] = useState({ role: "login", name: "", classId: null, className: "" });
+
+  const enterStudent = ({ name, classId, className }) => {
+    setSession({ role: "student", name, classId, className });
+    setTab("Onboarding");
+  };
+
+  const enterAdmin = () => {
+    setSession({ role: "admin", name: "Administrator", classId: null, className: "" });
+    setTab("Admin");
+  };
+
+  const logout = () => {
+    setSession({ role: "login", name: "", classId: null, className: "" });
+    setTab("Onboarding");
+  };
+
+  const tabItems = session.role === "admin"
+    ? ["Admin"]
+    : ["Onboarding","Accounts","Transactions","Recurring","Budgets","Statements"];
+
+  const showingLogin = session.role === "login";
 
   return (
     <div className="min-h-screen text-white p-4 md:p-8 bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900">
       <div className="max-w-5xl mx-auto">
-        <header className="mb-6 flex items-center justify-between">
+        <header className="mb-6 flex flex-col md:flex-row md:items-center md:justify-between gap-3">
           <div>
             <h1 className="text-2xl font-bold">TeenBank</h1>
             <p className="text-sm opacity-80">Very base website model · in‑memory</p>
           </div>
+          {session.role !== "login" && (
+            <div className="flex items-center gap-3 text-sm">
+              <div className="opacity-80">
+                {session.role === "admin" ? (
+                  <span>Logged in as Admin</span>
+                ) : (
+                  <span>Student: {session.name}{session.className ? ` · ${session.className}` : ""}</span>
+                )}
+              </div>
+              <Button onClick={logout} className="bg-white/15">Log out</Button>
+            </div>
+          )}
         </header>
 
-        <Tabs tab={tab} setTab={setTab} />
+        {showingLogin ? (
+          <LoginScreen state={state} setState={setState} onStudentEnter={enterStudent} onAdminEnter={enterAdmin} />
+        ) : (
+          <>
+            <Tabs tab={tab} setTab={setTab} items={tabItems} />
 
-        {tab === "Onboarding" && <Onboarding state={state} setState={setState} />}
-        {tab === "Accounts" && <Accounts state={state} setState={setState} />}
-        {tab === "Transactions" && <Transactions state={state} setState={setState} />}
-        {tab === "Classes" && <Classes state={state} setState={setState} />}
-        {tab === "Recurring" && <Recurring state={state} setState={setState} />}
-        {tab === "Budgets" && <Budgets state={state} setState={setState} />}
-        {tab === "Statements" && <Statements state={state} />}
-        {tab === "Admin" && <AdminPanel state={state} setState={setState} />}
+            {session.role !== "admin" && tab === "Onboarding" && <Onboarding state={state} setState={setState} />}
+            {session.role !== "admin" && tab === "Accounts" && <Accounts state={state} setState={setState} />}
+            {session.role !== "admin" && tab === "Transactions" && <Transactions state={state} setState={setState} />}
+            {session.role !== "admin" && tab === "Recurring" && <Recurring state={state} setState={setState} />}
+            {session.role !== "admin" && tab === "Budgets" && <Budgets state={state} setState={setState} />}
+            {session.role !== "admin" && tab === "Statements" && <Statements state={state} />}
+            {session.role === "admin" && tab === "Admin" && <AdminPanel state={state} setState={setState} />}
+          </>
+        )}
 
         <footer className="mt-8 text-xs opacity-70">© {new Date().getFullYear()} TeenBank (prototype)</footer>
       </div>


### PR DESCRIPTION
## Summary
- add in-memory classes with sample data
- provide a student join form for entering class codes
- add an admin tab to review rosters and create additional classes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f438d9628c8327a7fe7009fbd321ff