### PR TITLE
Add class enrollment interface

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,6 +26,11 @@ const initialState = {
   transactions: [],
   recurring: [],
   budgets: [],
+  classes: [
+    { id: uid("class"), name: "Financial Literacy 101", code: "FL101" },
+    { id: uid("class"), name: "Smart Budgeting", code: "BUDGET" },
+  ],
+  classMemberships: [],
 };
 
 function clone(x){ return JSON.parse(JSON.stringify(x)); }
@@ -103,6 +108,83 @@ function Onboarding({ state, setState }){
         )}
       </div>
     </Card>
+  );
+}
+
+function Classes({ state, setState }){
+  const user = state.users[0];
+  const [code, setCode] = useState("");
+  const [status, setStatus] = useState(null);
+
+  const join = () => {
+    const trimmed = code.trim().toUpperCase();
+    if (!trimmed) {
+      setStatus({ type: "error", message: "Enter a class code to join." });
+      return;
+    }
+    const cls = state.classes.find(c => c.code.toUpperCase() === trimmed);
+    if (!cls) {
+      setStatus({ type: "error", message: "We couldn't find a class with that code." });
+      return;
+    }
+    const already = state.classMemberships.some(m => m.classId === cls.id && m.userId === user.id);
+    if (already) {
+      setStatus({ type: "info", message: `You're already enrolled in ${cls.name}.` });
+      return;
+    }
+    const copy = clone(state);
+    copy.classMemberships.push({ id: uid("membership"), classId: cls.id, userId: user.id, joinedAt: new Date() });
+    setState(copy);
+    setCode("");
+    setStatus({ type: "success", message: `Welcome to ${cls.name}!` });
+  };
+
+  const classesWithMembers = state.classes.map(cls => ({
+    ...cls,
+    members: state.classMemberships
+      .filter(m => m.classId === cls.id)
+      .map(m => state.users.find(u => u.id === m.userId))
+      .filter(Boolean),
+  }));
+
+  const statusColor = status?.type === "success" ? "text-green-300" : status?.type === "error" ? "text-red-300" : "text-blue-200";
+
+  return (
+    <div className="grid md:grid-cols-2 gap-4">
+      <Card title="Join a Class">
+        <Field label="Class Code">
+          <input value={code} onChange={e=>setCode(e.target.value)} placeholder="FL101" className="w-full px-3 py-2 rounded-xl bg-white/10 border border-white/15 uppercase tracking-wide"/>
+        </Field>
+        <Button onClick={join}>Join Class</Button>
+        {status && <div className={`mt-3 text-sm ${statusColor}`}>{status.message}</div>}
+      </Card>
+
+      <Card title="Class Directory" footer="Admin view of available classes and current members.">
+        <div className="space-y-3 max-h-80 overflow-auto pr-1">
+          {classesWithMembers.map(cls => (
+            <div key={cls.id} className="bg-white/5 rounded-xl p-3">
+              <div className="flex items-center justify-between mb-2">
+                <div>
+                  <div className="font-semibold">{cls.name}</div>
+                  <div className="text-xs opacity-70">Code: {cls.code}</div>
+                </div>
+                <div className="text-xs opacity-70">{cls.members.length} member{cls.members.length === 1 ? "" : "s"}</div>
+              </div>
+              {cls.members.length > 0 ? (
+                <ul className="list-disc ml-5 space-y-1 text-sm">
+                  {cls.members.map(m => (
+                    <li key={m.id}>{m.name}</li>
+                  ))}
+                </ul>
+              ) : (
+                <div className="text-xs opacity-70">No students joined yet.</div>
+              )}
+            </div>
+          ))}
+          {classesWithMembers.length === 0 && <div className="opacity-70">No classes have been created.</div>}
+        </div>
+      </Card>
+    </div>
   );
 }
 
@@ -422,7 +504,7 @@ function Statements({ state }){
 
 // -------------------- App Shell --------------------
 function Tabs({ tab, setTab }){
-  const items = ["Onboarding","Accounts","Transactions","Recurring","Budgets","Statements"];
+  const items = ["Onboarding","Classes","Accounts","Transactions","Recurring","Budgets","Statements"];
   return (
     <div className="flex flex-wrap gap-2 mb-4">
       {items.map(name => (
@@ -449,6 +531,7 @@ export default function TeenBankApp(){
         <Tabs tab={tab} setTab={setTab} />
 
         {tab === "Onboarding" && <Onboarding state={state} setState={setState} />}
+        {tab === "Classes" && <Classes state={state} setState={setState} />}
         {tab === "Accounts" && <Accounts state={state} setState={setState} />}
         {tab === "Transactions" && <Transactions state={state} setState={setState} />}
         {tab === "Recurring" && <Recurring state={state} setState={setState} />}


### PR DESCRIPTION
## Summary
- add in-memory class catalog and membership tracking
- allow students to join classes using a class code
- surface an admin directory view that lists classes and their enrolled members

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68f6b70801848327853ef32d6f4bb6dd